### PR TITLE
Add schedule to serverless file

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -48,6 +48,8 @@ functions:
   entry:
     handler: handler.entry
     description: Description of the function
+    events:
+      - schedule: cron(20 7 ? * MON *)
   test:
     handler: handler.test
 


### PR DESCRIPTION
In the interest of moving towards full configuration with serverless, let's move the schedule trigger into serverless.yml instead of configuring the trigger in the aws web console.